### PR TITLE
Allow boolean values in pillar

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -10,3 +10,11 @@ vsftpd_config:
   pam_service_name: 'vsftpd'
   rsa_cert_file: '/etc/ssl/certs/ssl-cert-snakeoil.pem'
   rsa_private_key_file: '/etc/ssl/private/ssl-cert-snakeoil.key'
+
+
+
+# or use booleans
+vsftpd_config:
+  listen: true
+  anonymous_enable: false
+  local_enable: true

--- a/vsftpd/files/vsftpd.conf
+++ b/vsftpd/files/vsftpd.conf
@@ -6,6 +6,12 @@
 {#- and unknown options -#}
 {%- macro render_option(keyword, default, config_dict=vsftpd_config) -%}
   {%- set value = config_dict.get(keyword, default) -%}
+  {%- if value is sameas false -%}
+    {%- set value = 'NO' -%}
+  {%- endif -%}
+  {%- if value is sameas true -%}
+    {%- set value = 'YES' -%}
+  {%- endif -%}
   {%- if value is string or value is number -%}
 {{ keyword }}={{ value }}
   {%- else -%}


### PR DESCRIPTION
With this change the formula allows use of standard yaml boolean values instead of 'YES'/'NO' strings in pillar.