### PR TITLE
Config state first run fixes

### DIFF
--- a/vsftpd/config.sls
+++ b/vsftpd/config.sls
@@ -7,5 +7,6 @@ vsftpd_config:
     - template: jinja
     - user: root
     - mode: 644
+    - makedirs: true
     - watch_in:
       - service: {{ vsftpd.service }}

--- a/vsftpd/config.sls
+++ b/vsftpd/config.sls
@@ -1,8 +1,5 @@
 {% from "vsftpd/map.jinja" import vsftpd with context %}
 
-include:
-  - vsftpd
-
 vsftpd_config:
   file.managed:
     - name: {{ vsftpd.vsftpd_config }}
@@ -12,4 +9,3 @@ vsftpd_config:
     - mode: 644
     - watch_in:
       - service: {{ vsftpd.service }}
-


### PR DESCRIPTION
Fixes the problem when you use this formula's main state `vsftpd` where the `vsftpd_config` state will fail on the first run due to the config file path not being available.  I also removed the include of the main `vsftpd` state since the config is broken out in its own state so you can choose to manage only the config while not managing the package and service.